### PR TITLE
treewide: migrate to VuePress 2.0.0-beta50

### DIFF
--- a/components/AutoLink.vue
+++ b/components/AutoLink.vue
@@ -14,7 +14,7 @@ import { isLinkHttp, isLinkMailto, isLinkTel } from '@vuepress/shared'
 import { computed, toRefs } from 'vue'
 import type { PropType } from 'vue'
 import { useRoute } from 'vue-router'
-import type { NavLink } from '@vuepress/theme-default/lib/shared'
+import type { NavLink } from '@vuepress/theme-default/shared'
 
 const props = defineProps({
   item: {

--- a/components/Home.vue
+++ b/components/Home.vue
@@ -4,9 +4,9 @@ import HomeFeatures from '@theme/HomeFeatures.vue'
 import HomeFooter from '@theme/HomeFooter.vue'
 import HomeHero from '@theme/HomeHero.vue'
 
-import { useThemeLocaleData } from '@vuepress/theme-default/lib/client/composables'
+import { useThemeLocaleData } from '@vuepress/theme-default/client'
 import { usePageFrontmatter } from '@vuepress/client'
-import type { DefaultThemePageFrontmatter } from '@vuepress/theme-default/lib/shared'
+import type { DefaultThemePageFrontmatter } from '@vuepress/theme-default/shared'
 
 const adUnits = useThemeLocaleData().value.adUnits
 const frontmatter = usePageFrontmatter<DefaultThemePageFrontmatter>()

--- a/components/HomeHero.vue
+++ b/components/HomeHero.vue
@@ -9,8 +9,8 @@ import {
 import { isArray } from '@vuepress/shared'
 import type { FunctionalComponent } from 'vue'
 import { computed, h } from 'vue'
-import type { DefaultThemeHomePageFrontmatter } from '@vuepress/theme-default/lib/shared'
-import { useDarkMode } from '@vuepress/theme-default/lib/client/composables'
+import type { DefaultThemeHomePageFrontmatter } from '@vuepress/theme-default/shared'
+import { useDarkMode } from '@vuepress/theme-default/client'
 
 const frontmatter = usePageFrontmatter<DefaultThemeHomePageFrontmatter>()
 const siteLocale = useSiteLocaleData()

--- a/components/NavbarDropdown.vue
+++ b/components/NavbarDropdown.vue
@@ -4,7 +4,7 @@ import DropdownTransition from '@theme/DropdownTransition.vue'
 import { computed, ref, toRefs, watch } from 'vue'
 import type { PropType } from 'vue'
 import { useRoute } from 'vue-router'
-import type { NavbarItem, ResolvedNavbarItem } from '@vuepress/theme-default/lib/shared'
+import type { NavbarItem, ResolvedNavbarItem } from '@vuepress/theme-default/shared'
 
 const props = defineProps({
   item: {

--- a/components/Page.vue
+++ b/components/Page.vue
@@ -3,14 +3,14 @@ import PageMeta from '@theme/PageMeta.vue'
 import PageNav from '@theme/PageNav.vue'
 
 import { usePageData, usePageFrontmatter } from '@vuepress/client'
-import type { DefaultThemePageFrontmatter } from '@vuepress/theme-default/lib/shared'
+import type { DefaultThemePageFrontmatter } from '@vuepress/theme-default/shared'
 const frontmatter = usePageFrontmatter<DefaultThemePageFrontmatter>()
 
 const pageTitle = frontmatter.value.title
 const chartType = frontmatter.value.chartType || ''
 const widePage = frontmatter.value.widePage || false
 
-import { useThemeLocaleData } from '@vuepress/theme-default/lib/client/composables'
+import { useThemeLocaleData } from '@vuepress/theme-default/client'
 const adUnits = useThemeLocaleData().value.adUnits
 </script>
 

--- a/components/PageMeta.vue
+++ b/components/PageMeta.vue
@@ -11,9 +11,9 @@ import type {
   DefaultThemeNormalPageFrontmatter,
   DefaultThemePageData,
   NavLink,
-} from '@vuepress/theme-default/lib/shared'
-import { useThemeLocaleData } from '@vuepress/theme-default/lib/client/composables'
-import { resolveEditLink } from '@vuepress/theme-default/lib/client/utils'
+} from '@vuepress/theme-default/shared'
+import { useThemeLocaleData } from '@vuepress/theme-default/client'
+import { resolveEditLink } from '@vuepress/theme-default/client'
 
 const useEditNavLink = (): ComputedRef<null | NavLink> => {
   const themeLocale = useThemeLocaleData()

--- a/components/ToggleColorModeButton.vue
+++ b/components/ToggleColorModeButton.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useDarkMode, useThemeLocaleData } from '@vuepress/theme-default/lib/client/composables'
+import { useDarkMode, useThemeLocaleData } from '@vuepress/theme-default/client'
 
 const themeLocale = useThemeLocaleData()
 const isDarkMode = useDarkMode()

--- a/layouts/404.vue
+++ b/layouts/404.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useRouteLocale } from '@vuepress/client'
-import { useThemeLocaleData } from '@vuepress/theme-default/lib/client/composables'
+import { useThemeLocaleData } from '@vuepress/theme-default/client'
 
 const routeLocale = useRouteLocale()
 const themeLocale = useThemeLocaleData()

--- a/layouts/Layout.vue
+++ b/layouts/Layout.vue
@@ -1,9 +1,9 @@
 <script setup>
-import ParentLayout from '@vuepress/theme-default/lib/client/layouts/Layout.vue'
+import ParentLayout from '@vuepress/theme-default/layouts/Layout.vue'
 import { computed } from 'vue'
 
 import { usePageFrontmatter } from '@vuepress/client'
-import { useThemeLocaleData } from '@vuepress/plugin-theme-data/lib/client'
+import { useThemeLocaleData } from '@vuepress/plugin-theme-data/client'
 import MarkdownIt from 'markdown-it'
 const frontmatter = usePageFrontmatter()
 const themeLocaleData = useThemeLocaleData()

--- a/styles/navbar.scss
+++ b/styles/navbar.scss
@@ -6,10 +6,6 @@
     -webkit-backdrop-filter: blur(50px);
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.02), 0 2px 6px rgba(0, 0, 0, 0.06);
     border-bottom: 0;
-
-    .search-box input {
-        background: rgba(0,0,0,0) url('@vuepress/plugin-search/client/styles/search.svg') 0.6rem 0.5rem no-repeat;
-    }
 }
 
 html.dark .navbar {

--- a/styles/navbar.scss
+++ b/styles/navbar.scss
@@ -8,7 +8,7 @@
     border-bottom: 0;
 
     .search-box input {
-        background: rgba(0,0,0,0) url('@vuepress/plugin-search/lib/client/styles/search.svg') 0.6rem 0.5rem no-repeat;
+        background: rgba(0,0,0,0) url('@vuepress/plugin-search/client/styles/search.svg') 0.6rem 0.5rem no-repeat;
     }
 }
 


### PR DESCRIPTION
This pull request updates the theme code to compile with updated VuePress engine.

Only change needed was to fix all the imports into ones explicitly defined in `exports` for each `package.json`. The search box scss was removed as it still works without it and there isn't a way to make that import properly anymore.


It also doesn't work with beta 51, the theme compiles but basically does nothing there. Needs more looking into, but at least we got one more version.